### PR TITLE
Seed data for muscle_groups

### DIFF
--- a/migrations/1544034702_seed-muscle-groups.sql
+++ b/migrations/1544034702_seed-muscle-groups.sql
@@ -1,0 +1,9 @@
+-- Migrate:
+INSERT INTO muscle_groups(
+    muscle_group
+)
+VALUES 
+    ('Chest'), ('Back'), ('Biceps'), ('Triceps'), ('Shoulders'), ('Legs'), ('Abs')
+;
+-- Revert:
+DELETE FROM muscle_groups;


### PR DESCRIPTION
Fixes #60 

Messed up migrations here. 
Problem: Typed command - ash migrate:make seed-mg-table
Deleted the file when switching branches, tried to ash migrate make again with a new file
Got "Migration file is misformatted" error.

Solution: Go into psql and remove the erroneous migration entries manually.
Check in ash_migrations table under the database used for this project.
The named migration x will be there, 'delete from ash_migrations where id = x;'
